### PR TITLE
Building with general CUDA version

### DIFF
--- a/src/linux/Makefile
+++ b/src/linux/Makefile
@@ -36,7 +36,7 @@
 include ./findcudalib.mk
 
 # Location of the CUDA Toolkit
-CUDA_PATH ?= "/usr/local/cuda-5.5"
+CUDA_PATH ?= "/usr/local/cuda"
 
 # internal flags
 NVCCFLAGS   := -m${OS_SIZE} -maxrregcount=16
@@ -131,14 +131,14 @@ svm-train-gpu.o: svm.cpp svm-train.o
 
 svm-train-gpu: svm.o svm-train.o
 	$(NVCC) $(ALL_LDFLAGS) -o $@ $+ $(LIBRARIES)
-	mkdir -p /bin/$(OS_ARCH)/$(OSLOWER)/$(TARGET)$(if $(abi),/$(abi))
-	cp $@ /bin/$(OS_ARCH)/$(OSLOWER)/$(TARGET)$(if $(abi),/$(abi))
+	mkdir -p bin/$(OS_ARCH)/$(OSLOWER)/$(TARGET)$(if $(abi),/$(abi))
+	cp $@ bin/$(OS_ARCH)/$(OSLOWER)/$(TARGET)$(if $(abi),/$(abi))
 
 run: build
 	./svm-train-gpu
 
 clean:
 	rm -f svm-train-gpu.o svm-train-gpu
-	rm -rf /bin/$(OS_ARCH)/$(OSLOWER)/$(TARGET)$(if $(abi),/$(abi))/svm-train-gpu
+	rm -rf bin/$(OS_ARCH)/$(OSLOWER)/$(TARGET)$(if $(abi),/$(abi))/svm-train-gpu
 
 clobber: clean

--- a/src/linux/kernel_matrix_calculation.c
+++ b/src/linux/kernel_matrix_calculation.c
@@ -1,5 +1,5 @@
-#include "/usr/local/cuda-5.5/include/cuda_runtime.h"
-#include "/usr/local/cuda-5.5/include/cublas_v2.h"
+#include "/usr/local/cuda/include/cuda_runtime.h"
+#include "/usr/local/cuda/include/cublas_v2.h"
 
 // Scalars
 const float alpha = 1;


### PR DESCRIPTION
Hey,

I know this is probably obsolete package (last update was 3 years ago), but I wanted to add it to my thesis and hence I needed to make it run with recent CUDA version (v7 in my case).

I was able to build it with just these few little changes, basically changing `cuda-5.5` references to `cuda`, which points to current installed version. That is dangerous for those who don't know what that means, but for people who understand what happens this might be still used even without having to use `cuda 5.5`. 

Another minor change is that I am not building it into system `/bin` directory (which is very bad idea on most distributions).